### PR TITLE
fix: deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: gradlew 실행 권한 부여
-        run: chmod +x gradlew
-
-      - name: Gradle 빌드
-        run: ./gradlew build -x test
+      - name: gradlew 실행 권한 부여, Gradle 빌드
+        working-directory: backend
+        run: | 
+          chmod +x gradlew
+          ./gradlew build -x test
 
       - name: Docker Hub 로그인
         uses: docker/login-action@v2


### PR DESCRIPTION
## 📌 배포

deploy.yml 파일 내,
Github Actions workflows 과정에서 gradlew의 경로가 root가 아닌, backend 내, backend/gradlew 위치에 있어서 수정했습니다.

이전 PR에서 main -> dev, 반대로 merge를 실행시켜서 
```
git reset --hard 40ed783  
```
명령어로 되돌린 후 다시 Merge를 시도합니다.

## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
