### PR TITLE
43/refactor/raffle lnf valid

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/lostfound/controller/LnfController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/lostfound/controller/LnfController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.passtival.backend.domain.lostfound.model.request.FoundItemRequest;
 import com.passtival.backend.domain.lostfound.service.LnfService;
 import com.passtival.backend.global.common.BaseResponse;
-import com.passtival.backend.global.exception.BaseException;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,23 +18,21 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/foundItem")
+@RequestMapping("/api/found-items")
 @Tag(name = "Lost and Found API", description = "분실물 관리 API")
 public class LnfController {
 
 	private final LnfService lnfService;
 
-	/**
-	 * 이미지 업로드 URL 조회 API
-	 * @param fileName 업로드할 파일명
-	 * @return S3 Presigned Upload URL
-	 */
 	@Operation(
 		summary = "이미지 업로드 URL 조회",
 		description = "클라이언트가 S3에 직접 이미지를 업로드하기 위한 Presigned URL을 생성합니다.",
@@ -50,16 +47,16 @@ public class LnfController {
 		}
 	)
 	@GetMapping("/upload-url")
-	public BaseResponse<String> getUploadUrl(@RequestParam String fileName) throws BaseException {
+	public BaseResponse<String> getUploadUrl(
+		@RequestParam
+		@NotBlank(message = "파일명은 필수입니다.")
+		@Pattern(regexp = "^[a-zA-Z0-9._-]+\\.(jpg|jpeg|png|gif)$",
+			message = "유효한 이미지 파일명이어야 합니다.")
+		String fileName) {
 		String uploadUrl = lnfService.getUploadUrl(fileName);
 		return BaseResponse.success(uploadUrl);
 	}
 
-	/**
-	 * 분실물 등록 API
-	 * @param request 분실물 등록 요청 정보
-	 * @return 등록 완료 응답
-	 */
 	@Operation(
 		summary = "분실물 등록",
 		description = "습득한 분실물의 정보를 등록합니다. 이미지는 사전에 업로드하고 해당 URL을 포함해야 합니다.",
@@ -83,8 +80,8 @@ public class LnfController {
 			)
 		)
 	)
-	@PostMapping("/create")
-	public BaseResponse<Void> createFoundItem(@RequestBody FoundItemRequest request) throws BaseException {
+	@PostMapping
+	public BaseResponse<Void> createFoundItem(@Valid @RequestBody FoundItemRequest request) {
 		lnfService.createFoundItem(request);
 		return BaseResponse.success(null);
 	}

--- a/backend/src/main/java/com/passtival/backend/domain/lostfound/model/request/FoundItemRequest.java
+++ b/backend/src/main/java/com/passtival/backend/domain/lostfound/model/request/FoundItemRequest.java
@@ -2,6 +2,7 @@ package com.passtival.backend.domain.lostfound.model.request;
 
 import java.time.LocalDateTime;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,9 +10,15 @@ import lombok.Getter;
 @Builder
 public class FoundItemRequest {
 
+	@NotBlank(message = "제목은 필수입니다.")
 	private String title;
+
+	@NotBlank(message = "위치는 필수입니다.")
 	private String area;
+
+	@NotBlank(message = "시간 입력은 필수입니다.")
 	private LocalDateTime foundDateTime;
+
 	private String imagePath;
 
 }

--- a/backend/src/main/java/com/passtival/backend/domain/lostfound/service/LnfService.java
+++ b/backend/src/main/java/com/passtival/backend/domain/lostfound/service/LnfService.java
@@ -9,6 +9,7 @@ import com.passtival.backend.global.common.BaseResponseStatus;
 import com.passtival.backend.global.exception.BaseException;
 import com.passtival.backend.global.s3.S3Service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,7 +21,8 @@ public class LnfService {
 	private final LnfRepository lnfRepository;
 	private final S3Service s3Service;
 
-	public void createFoundItem(FoundItemRequest request) throws BaseException {
+	@Transactional
+	public void createFoundItem(FoundItemRequest request) {
 		// FoundItem 엔티티 생성
 		try {
 			FoundItem foundItem = FoundItem.builder()

--- a/backend/src/main/java/com/passtival/backend/domain/raffle/controller/RaffleController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/raffle/controller/RaffleController.java
@@ -90,7 +90,7 @@ public class RaffleController {
 		)
 	)
 	@PostMapping("/applicants")
-	public BaseResponse<Void> saveApplicant(@RequestBody ApplicantRegistrationRequest request) {
+	public BaseResponse<Void> saveApplicant(@Valid @RequestBody ApplicantRegistrationRequest request) {
 		/* 1. 클라이언트로부터 신청자의 이름과 학번, 인증키 입력받는다.
 		 * 2. 신청자의 이름과 학번을 기반으로 신청자를 데이터베이스에 저장한다.
 		 * 3. 신청이 완료되면 클라이언트에게 성공 메시지를 반환한다.

--- a/backend/src/main/java/com/passtival/backend/domain/raffle/model/entity/AuthenticationKey.java
+++ b/backend/src/main/java/com/passtival/backend/domain/raffle/model/entity/AuthenticationKey.java
@@ -22,17 +22,13 @@ public class AuthenticationKey extends BaseEntity {
 	private Long id;
 
 	@Column(name = "authentication_key", nullable = false, unique = true)
-	private String key; // 인증 키 값
+	private String authenticationKey; // 인증 키 값
 
 	public AuthenticationKey(String key) {
-		this.key = key;
+		this.authenticationKey = key;
 	}
 
-	/**
-	 * 인증 키를 업데이트합니다.
-	 * @param newKey 새로운 인증 키
-	 */
 	public void updateKey(String newKey) {
-		this.key = newKey;
+		this.authenticationKey = newKey;
 	}
 }

--- a/backend/src/main/java/com/passtival/backend/domain/raffle/model/request/ApplicantRegistrationRequest.java
+++ b/backend/src/main/java/com/passtival/backend/domain/raffle/model/request/ApplicantRegistrationRequest.java
@@ -1,15 +1,22 @@
 package com.passtival.backend.domain.raffle.model.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class ApplicantRegistrationRequest {
 
-	@NotBlank
+	@NotBlank(message = "신청자 이름은 필수입니다.")
+	@Pattern(regexp = "^[가-힣]{2,5}$", message = "신청자 이름은 2~5글자의 한글로 입력해주세요.")
 	private String applicantName; // 신청자 이름
-	@NotBlank
-	private String studentId; // 신청자 학번
-	@NotBlank
-	private String key; // 인증키
+
+	@NotBlank(message = "학번은 필수입니다.")
+	@Pattern(regexp = "^[A-Za-z0-9]$", message = "학번은 영어와 숫자만 입력해주세요.")
+	private String studentId;
+
+	@NotBlank(message = "인증키는 필수입니다.")
+	@Size(min = 4, max = 20, message = "인증키는 4자 이상 20자 이하여야 합니다.")
+	private String authenticationKey; // 인증키
 }

--- a/backend/src/main/java/com/passtival/backend/domain/raffle/model/request/UpdateAuthenticationKeyRequest.java
+++ b/backend/src/main/java/com/passtival/backend/domain/raffle/model/request/UpdateAuthenticationKeyRequest.java
@@ -6,8 +6,9 @@ import lombok.Getter;
 @Getter
 public class UpdateAuthenticationKeyRequest {
 
-	@NotBlank
+	@NotBlank(message = "새로운 인증키는 필수입니다.")
 	private String newKey;
-	@NotBlank
+
+	@NotBlank(message = "기존 인증키는 필수입니다.")
 	private String oldKey;
 }

--- a/backend/src/main/java/com/passtival/backend/domain/raffle/service/PrizeService.java
+++ b/backend/src/main/java/com/passtival/backend/domain/raffle/service/PrizeService.java
@@ -25,7 +25,7 @@ public class PrizeService {
 	 * 상품 목록 조회
 	 * @return 상품 목록
 	 */
-	public List<PrizeResponse> getAllPrizes() throws BaseException {
+	public List<PrizeResponse> getAllPrizes() {
 		List<Prize> prizes = prizeRepository.findAll();
 		if (prizes.isEmpty()) {
 			throw new BaseException(BaseResponseStatus.PRIZES_NOT_FOUND);
@@ -38,7 +38,7 @@ public class PrizeService {
 	 * @param prizeId
 	 * @return 상품 정보
 	 */
-	public PrizeResponse getPrizeById(Long prizeId) throws BaseException {
+	public PrizeResponse getPrizeById(Long prizeId) {
 		Prize prize = prizeRepository.findById(prizeId)
 			.orElseThrow(() -> new BaseException(BaseResponseStatus.PRIZE_NOT_FOUND));
 		return PrizeResponse.of(prize);

--- a/backend/src/main/java/com/passtival/backend/domain/raffle/service/RaffleService.java
+++ b/backend/src/main/java/com/passtival/backend/domain/raffle/service/RaffleService.java
@@ -29,9 +29,10 @@ public class RaffleService {
 	 * 신청자 등록
 	 * @param request 신청자 등록 요청 정보
 	 */
-	public void registerApplicant(ApplicantRegistrationRequest request) throws BaseException {
+	@Transactional
+	public void registerApplicant(ApplicantRegistrationRequest request) {
 		// 1. 인증키 유효성 검사
-		validateAuthenticationKey(request.getKey());
+		validateAuthenticationKey(request.getAuthenticationKey());
 
 		// 2. 학번 중복 확인
 		if (applicantRepository.existsByStudentId(request.getStudentId())) {
@@ -52,10 +53,10 @@ public class RaffleService {
 	 * @param requestKey 요청에서 받은 인증키
 	 * @throws BaseException 인증키가 유효하지 않은 경우
 	 */
-	private void validateAuthenticationKey(String requestKey) throws BaseException {
+	private void validateAuthenticationKey(String requestKey) {
 		AuthenticationKey authKey = getCurrentAuthenticationKey();
 
-		if (!authKey.getKey().equals(requestKey)) {
+		if (!authKey.getAuthenticationKey().equals(requestKey)) {
 			throw new BaseException(BaseResponseStatus.INVALID_AUTH_KEY);
 		}
 	}
@@ -65,7 +66,7 @@ public class RaffleService {
 	 * @return 현재 인증키
 	 * @throws BaseException 인증키가 없는 경우
 	 */
-	private AuthenticationKey getCurrentAuthenticationKey() throws BaseException {
+	private AuthenticationKey getCurrentAuthenticationKey() {
 		AuthenticationKey authKey = authenticationKeyRepository.findFirstByOrderByIdAsc();
 
 		if (authKey == null) {
@@ -82,17 +83,17 @@ public class RaffleService {
 	 * @throws BaseException 인증키 검증 실패, DB 오류 시
 	 */
 	@Transactional
-	public void updateAuthenticationKey(String newKey, String oldKey) throws BaseException {
+	public void updateAuthenticationKey(String newKey, String oldKey) {
 		// 1. 현재 인증키 조회
 		AuthenticationKey currentAuthKey = getCurrentAuthenticationKey();
 
 		// 2. 기존 인증키 검증
-		if (!currentAuthKey.getKey().equals(oldKey)) {
+		if (!currentAuthKey.getAuthenticationKey().equals(oldKey)) {
 			throw new BaseException(BaseResponseStatus.INVALID_AUTH_KEY);
 		}
 
 		// 3. 새로운 키와 기존 키가 같은 경우 체크
-		if (currentAuthKey.getKey().equals(newKey)) {
+		if (currentAuthKey.getAuthenticationKey().equals(newKey)) {
 			throw new BaseException(BaseResponseStatus.SAME_AUTH_KEY);
 		}
 


### PR DESCRIPTION
## 개요

### 1. Exception에 대해서
`BaseException extends RuntimeException`으로 개선 후, 컨트롤러, 서비스 로직에서 모든 `throws BaseException`을 제거 했습니다.
RuntimeException은 `Unchecked Exception`이기 때문에, throws를 명시적으로 해줄 필요가 없습니다. 컴파일 단계에서 에러가 발생하지 않기 때문이죠.

여기서 우리는 Spring Framwork를 사용하며 예외를 어떻게 `처리` 해야할지 고민을 합니다.
Spring은 언체크 예외 중심으로 설계되었습니다. Spring MVC에서 아래와 같은 예외들을 던져주는데 이 예외들은 모두 `RuntimeException`을 상속받습니다.

1. ```HttpMessageNotReadableException.class```
2. ```MethodArgumentTypeMismatchException.class``` 
3.  ```ConstraintViolationException.class```
4.  ```TypeMismatchException.class```


**따라서 GlobalExceptionHandler로 모든 예외 처리 책임을 위임하여 AOP를 지향하는 코드를 작성하려고 합니다.**

### 2. @Valid

HTTP 요청을 받고, 응답하는 과정에서 Request(요청값)을 받게 되는데 우리는 이 값을 서비스 로직에서 검증했습니다.
우리가 작성한 코드는 가독성을 방해하고, 오류의 원인이 있습니다. 따라서 `@Valid `을 활용하여 클라이언트 서버로부터 검증을 받고, 실패시, 
```java
	@ExceptionHandler(MethodArgumentNotValidException.class)
	public BaseResponse<?> handleValidationException(MethodArgumentNotValidException e) {
		Map<String, String> errors = new HashMap<>();
		e.getBindingResult().getAllErrors().forEach((error) -> {
			String fieldName = ((FieldError)error).getField();
			String errorMessage = error.getDefaultMessage();
			errors.put(fieldName, errorMessage);
		});
		log.warn("요청 파라미터 검증 실패: {}", errors);
		return BaseResponse.fail(BaseResponseStatus.INVALID_REQUEST, errors);
``` 
에서 예외를 처리하게 됩니다.



<!---- Resolves: #(Isuue Number) -->
- close #43 

## PR 유형

### 📌 기능 추가(코드)
- [X] 새로운 기능 추가

### 📌 수정 및 변경(코드)
- [x] 코드 리팩토링


## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
