### PR TITLE
24/feature/performance api

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceController.java
@@ -17,11 +17,13 @@ import com.passtival.backend.global.common.BaseResponse;
 import com.passtival.backend.global.common.BaseResponseStatus;
 import com.passtival.backend.global.exception.BaseException;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/festival")
+@Tag(name = "Performance-API", description = "공연 조회 API")
 public class PerformanceController {
 
 	private final PerformanceService performanceService;

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
@@ -44,6 +44,11 @@ public class PerformanceSeedController {
 
 		validateKey(key);
 
+		// 요청 리스트 비어있을 때
+		if (performanceRequests == null || performanceRequests.isEmpty()) {
+			throw new BaseException(BaseResponseStatus.REQUEST_BODY_EMPTY);
+		}
+
 		for (PerformanceRequest req : performanceRequests) {
 
 			if (performanceRepository.existsByTitle(req.getTitle())) {
@@ -73,7 +78,7 @@ public class PerformanceSeedController {
 			performanceRepository.save(perf);
 		}
 
-		return BaseResponse.success("Performances inserted!");
+		return BaseResponse.success("Performances 데이터 삽입 성공!");
 	}
 
 

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
@@ -1,0 +1,80 @@
+package com.passtival.backend.domain.festival.performance.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.passtival.backend.domain.festival.performance.model.entity.Performance;
+import com.passtival.backend.domain.festival.performance.model.entity.Song;
+import com.passtival.backend.domain.festival.performance.model.request.PerformanceRequest;
+import com.passtival.backend.domain.festival.performance.repository.PerformanceRepository;
+import com.passtival.backend.global.common.BaseResponse;
+import com.passtival.backend.global.common.BaseResponseStatus;
+import com.passtival.backend.global.exception.BaseException;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/admin/seed")
+@RequiredArgsConstructor
+public class PerformanceSeedController {
+
+	private final PerformanceRepository performanceRepository;
+
+	@Value("${app.admin.seed-key}")
+	private String seedKey;
+
+	// 인증키 검증
+	private void validateKey(String key) {
+		if (!seedKey.equals(key)) {
+			throw new SecurityException("Invalid seed key");
+		}
+	}
+
+	@PostMapping("/performances")
+	public BaseResponse<?> insertPerformances(
+		@RequestHeader("X-ADMIN-KEY") String key,
+		@RequestBody @Valid List<PerformanceRequest> performanceRequests) {
+
+		validateKey(key);
+
+		for (PerformanceRequest req : performanceRequests) {
+
+			if (performanceRepository.existsByTitle(req.getTitle())) {
+				throw new BaseException(BaseResponseStatus.DUPLICATE_PERFORMANCE_TITLE);
+			}
+
+			Performance perf = Performance.builder()
+				.title(req.getTitle())
+				.artist(req.getArtist())
+				.area(req.getArea())
+				.imagePath(req.getImagePath())
+				.startTime(req.getStartTime())
+				.endTime(req.getEndTime())
+				.introduction(req.getIntroduction())
+				.day(req.getDay())
+				.build();
+
+			if (req.getSongs() != null) {
+				for (PerformanceRequest.SongRequest songReq : req.getSongs()) {
+					perf.addSong(Song.builder()
+						.title(songReq.getTitle())
+						.singer(songReq.getSinger())
+						.build());
+				}
+			}
+
+			performanceRepository.save(perf);
+		}
+
+		return BaseResponse.success("Performances inserted!");
+	}
+
+
+}

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
@@ -17,12 +17,14 @@ import com.passtival.backend.global.common.BaseResponse;
 import com.passtival.backend.global.common.BaseResponseStatus;
 import com.passtival.backend.global.exception.BaseException;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/admin/seed")
 @RequiredArgsConstructor
+@Tag(name = "Performance-Seeder-API", description = "공연 데이터 삽입 API")
 public class PerformanceSeedController {
 
 	private final PerformanceRepository performanceRepository;

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/model/request/PerformanceRequest.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/model/request/PerformanceRequest.java
@@ -1,0 +1,45 @@
+package com.passtival.backend.domain.festival.performance.model.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PerformanceRequest {
+
+	@NotBlank(message = "공연 이름은 비워둘 수 없습니다.")
+	private String title;
+
+	@NotBlank(message = "공연 진행 학과,동아리 이름은 비워둘 수 없습니다.")
+	private String artist;
+
+	@NotNull(message = "공연 시작시간은 비워둘 수 없습니다.")
+	private LocalDateTime startTime;
+
+	@NotNull(message = "공연 끝나는시간은 비워둘 수 없습니다.")
+	private LocalDateTime endTime;
+
+	@NotBlank(message = "공연 위치는 비워둘 수 없습니다.")
+	private String area;
+
+	private String imagePath;
+	private String introduction;
+	private Integer day;
+
+	private List<SongRequest> songs;
+
+	@Getter
+	@NoArgsConstructor
+	public static class SongRequest {
+		@NotBlank
+		private String singer;
+
+		@NotBlank
+		private String title;
+	}
+}

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/repository/PerformanceRepository.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/repository/PerformanceRepository.java
@@ -23,4 +23,6 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
 	List<Performance> findPageByCursor(@Param("cursorId") Long cursorId,
 		Pageable pageable);
 
+	boolean existsByTitle(String title);
+
 }

--- a/backend/src/main/java/com/passtival/backend/global/common/BaseResponseStatus.java
+++ b/backend/src/main/java/com/passtival/backend/global/common/BaseResponseStatus.java
@@ -51,6 +51,7 @@ public enum BaseResponseStatus {
 	ALREADY_APPLIED_MATCHING(false, 409, "이미 매칭 신청을 완료하였습니다."),
 	DUPLICATE_SOCIAL_ID(false, 409, "이미 사용 중인 소셜 ID입니다."),
 	ONBOARDING_ALREADY_COMPLETED(false, 409, "이미 온보딩이 완료된 사용자입니다."),
+	DUPLICATE_PERFORMANCE_TITLE(false, 409, "이미 존재하는 공연 주제입니다."),
 
 	// 422: 처리 불가능한 엔티티 (비즈니스 로직 오류)
 	INVALID_AUTH_KEY(false, 422, "인증키가 일치하지 않습니다."),

--- a/backend/src/main/java/com/passtival/backend/global/common/BaseResponseStatus.java
+++ b/backend/src/main/java/com/passtival/backend/global/common/BaseResponseStatus.java
@@ -42,6 +42,7 @@ public enum BaseResponseStatus {
 	NAME_INVALID(false, 404, "이름으로 등록된 데이터가 없습니다."),
 	PERFORMANCE_NOT_FOUND(false, 404, "등록된 공연이 없습니다."),
 	BOOTH_NOT_FOUND(false, 404, "부스이름으로 등록된 데이터가 없습니다."),
+	REQUEST_BODY_EMPTY(false, 404, "요청 데이터가 없습니다."),
 
 	// 409: 충돌
 	DUPLICATE_REQUEST(false, 409, "이미 처리된 요청입니다."),


### PR DESCRIPTION
## 데이터 저장 API
`POST` `http://localhost:8080/api/admin/seed/performances` : Header의 key에 X-ADMIN-KEY, value에 .env파일에 있는 APP_ADMIN_SEED_KEY로 정의되어있는 값으로 검증 -> JSON으로 데이터입력해서 요청

- close #24

## API요청
<img width="1010" height="577" alt="image" src="https://github.com/user-attachments/assets/4820da30-48c7-40a6-986e-3768436c826c" />


### 📌 기능 추가(코드)
- [x] 새로운 기능 추가

## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
