### PR TITLE
fix: 인증키 공통설정파일 수정 & 공통응답으로 수정

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothSeedController.java
@@ -36,7 +36,7 @@ public class BoothSeedController {
 	// 인증키 확인
 	private void validateKey(String key) {
 		if (!seedKey.equals(key)) {
-			throw new SecurityException("Invalid seed key");
+			throw new BaseException(BaseResponseStatus.INVALID_AUTH_KEY);
 		}
 	}
 

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
@@ -35,7 +35,7 @@ public class PerformanceSeedController {
 	// 인증키 검증
 	private void validateKey(String key) {
 		if (!seedKey.equals(key)) {
-			throw new SecurityException("Invalid seed key");
+			throw new BaseException(BaseResponseStatus.INVALID_AUTH_KEY);
 		}
 	}
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -55,3 +55,7 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION}
   refresh-token-expiration: ${JWT_REFRESH_EXPIRATION}
+
+app:
+  admin:
+    seed-key: ${APP_ADMIN_SEED_KEY}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -57,3 +57,7 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION}
   refresh-token-expiration: ${JWT_REFRESH_EXPIRATION}
+
+app:
+  admin:
+    seed-key: ${APP_ADMIN_SEED_KEY}


### PR DESCRIPTION
## 공통 설정에 코드 추가
공연와 부스&메뉴에 데이터를 넣는 API에 검증을 할때에 필요한 인증키 설정을 공통 파일에 추가하였습니다.
노션에 .env파일에 넣어야할 키 올려두겠습니다.

추가로 인증키가 맞지 않았을 때 코드를 SecurityException로 짰던 것을 공통응답처리인 BaseException으로 통일하는 것이 맞겠다고 판단하여 추가하였습니다.

- close #24

## PR 유형

### 📌 수정 및 변경(코드)
- [x] 코드 리팩토링

## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
