### PR TITLE
관리자 권한 도입 후, 분실물 인증키 로직 제거, Swagger 가독성 개선  #75,#76 to dev

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/authentication/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/authentication/controller/AuthenticationController.java
@@ -13,12 +13,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/authentication")
+@Tag(name = "인증키 관리 API", description = "인증키 변경")
 public class AuthenticationController {
 
 	private final AuthenticationService authenticationService;

--- a/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothController.java
@@ -16,8 +16,6 @@ import com.passtival.backend.domain.festival.booth.model.response.BoothResponse;
 import com.passtival.backend.domain.festival.booth.service.BoothService;
 import com.passtival.backend.domain.festival.menu.model.response.MenuResponse;
 import com.passtival.backend.global.common.BaseResponse;
-import com.passtival.backend.global.common.BaseResponseStatus;
-import com.passtival.backend.global.exception.BaseException;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/festival")
-@Tag(name = "Booth-Menu-API", description = "부스 & 메뉴 조회 API")
+@Tag(name = "부스 관련 API", description = "부스, 메뉴 조회")
 public class BoothController {
 
 	private final BoothService boothService;

--- a/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothSeedController.java
@@ -3,7 +3,6 @@ package com.passtival.backend.domain.festival.booth.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -25,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/admin/seed")
 @RequiredArgsConstructor
-@Tag(name = "Booth-Menu-Seeder-API", description = "부스 & 메뉴 데이터 삽입 API")
+@Tag(name = "데이터 주입 API", description = "공연, 부스, 메뉴 데이터 주입")
 public class BoothSeedController {
 
 	private final BoothRepository boothRepository;

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceController.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.passtival.backend.domain.festival.performance.model.entity.Performance;
 import com.passtival.backend.domain.festival.performance.model.response.PerformanceDetailResponse;
 import com.passtival.backend.domain.festival.performance.model.response.PerformanceResponse;
-import com.passtival.backend.domain.festival.performance.model.entity.Performance;
 import com.passtival.backend.domain.festival.performance.service.PerformanceService;
 import com.passtival.backend.global.common.BaseResponse;
 
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/festival")
-@Tag(name = "Performance-API", description = "공연 목록 조회 API")
+@Tag(name = "공연 관련 API", description = "공연 조회")
 public class PerformanceController {
 
 	private final PerformanceService performanceService;
@@ -63,7 +63,5 @@ public class PerformanceController {
 		PerformanceDetailResponse detail = performanceService.getPerformanceById(performanceId);
 		return BaseResponse.success(detail);
 	}
-
-
 
 }

--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/controller/PerformanceSeedController.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/admin/seed")
 @RequiredArgsConstructor
-@Tag(name = "Performance-Seeder-API", description = "공연 데이터 삽입 API")
+@Tag(name = "데이터 주입 API", description = "공연, 부스, 메뉴 데이터 주입")
 public class PerformanceSeedController {
 
 	private final PerformanceRepository performanceRepository;
@@ -82,6 +82,5 @@ public class PerformanceSeedController {
 
 		return BaseResponse.success("Performances 데이터 삽입 성공!");
 	}
-
 
 }

--- a/backend/src/main/java/com/passtival/backend/domain/lostfound/controller/AdminAuthController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/lostfound/controller/AdminAuthController.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
-@Tag(name = "Login-API", description = "분실물 관리자 로그인")
+@Tag(name = "로그인 관련 API", description = "분실물 관리자 로그인, 번호팅 카카오 로그인")
 public class AdminAuthController {
 	private final AdminAuthService adminAuthService;
 

--- a/backend/src/main/java/com/passtival/backend/domain/lostfound/controller/AdminAuthController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/lostfound/controller/AdminAuthController.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
-@Tag(name = "Lost-and-Found-Login", description = "분실물 관리자 로그인")
+@Tag(name = "Login-API", description = "분실물 관리자 로그인")
 public class AdminAuthController {
 	private final AdminAuthService adminAuthService;
 
@@ -52,7 +52,6 @@ public class AdminAuthController {
 			)
 		)
 	)
-
 	@PostMapping("/login")
 	public BaseResponse<TokenResponse> login(
 		@Valid @RequestBody AdminLoginRequest requestDto) {

--- a/backend/src/main/java/com/passtival/backend/domain/lostfound/service/LnfService.java
+++ b/backend/src/main/java/com/passtival/backend/domain/lostfound/service/LnfService.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.passtival.backend.domain.authentication.service.AuthenticationService;
 import com.passtival.backend.domain.lostfound.model.entity.FoundItem;
 import com.passtival.backend.domain.lostfound.model.request.FoundItemRequest;
 import com.passtival.backend.domain.lostfound.model.response.FoundItemResponse;
@@ -23,14 +22,10 @@ import lombok.extern.slf4j.Slf4j;
 public class LnfService {
 
 	private final LnfRepository lnfRepository;
-	private final AuthenticationService authenticationService;
 	private final S3Service s3Service;
 
 	@Transactional
 	public void createFoundItem(FoundItemRequest request) {
-		// 인증키 유효성 검사
-		authenticationService.validateAuthenticationKey(request.getAuthenticationKey());
-
 		FoundItem foundItem = FoundItem.builder()
 			.title(request.getTitle())
 			.area(request.getArea())
@@ -39,7 +34,6 @@ public class LnfService {
 			.build();
 
 		lnfRepository.save(foundItem);
-
 	}
 
 	public String getUploadUrl(String fileName) {
@@ -47,10 +41,7 @@ public class LnfService {
 	}
 
 	@Transactional
-	public void deleteFoundItem(Long id, String authenticationKey) {
-
-		// 인증키 유효성 검사
-		authenticationService.validateAuthenticationKey(authenticationKey);
+	public void deleteFoundItem(Long id) {
 
 		if (!lnfRepository.existsById(id)) {
 			throw new BaseException(BaseResponseStatus.FOUND_ITEM_NOT_FOUND);

--- a/backend/src/main/java/com/passtival/backend/domain/matching/controller/MatchingController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/matching/controller/MatchingController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
  * 매칭 관련 API를 처리하는 컨트롤러
  * 프로젝트의 BaseResponse 응답 규격화를 따라 일관된 응답 구조 제공
  */
-@Tag(name = "Matching-API", description = "매칭 관리 API")
+@Tag(name = "번호팅 관련 API", description = "매칭 신청 및 결과 조회")
 @RestController
 @RequestMapping("/api/matching")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/passtival/backend/domain/matching/controller/MemberController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/matching/controller/MemberController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/matching/members")
 @RequiredArgsConstructor
-@Tag(name = "Member-API", description = "회원 관리 API")
+@Tag(name = "번호팅 회원 관련 API", description = "번호팅 정보 수집, 프로필 조회")
 public class MemberController {
 
 	private final MemberService memberService;
@@ -38,7 +38,7 @@ public class MemberController {
 
 	//소셜 로그인 이후에 추가 정보를 얻는 로직 추가 예정
 	@Operation(
-		summary = "온보딩 (추가 정보 입력)",
+		summary = "정보 저장 (추가 정보 입력)",
 		description = "소셜 로그인으로 가입된 사용자가 추가 정보(성별, 전화번호)를 입력 **인증 토큰이 필요합니다.**\n"
 			+ "성별 (필수): db에 성별이 없으면 실패"
 			+ "전화번호 허용 형식: \"010-1234-5678\""

--- a/backend/src/main/java/com/passtival/backend/domain/raffle/controller/RaffleController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/raffle/controller/RaffleController.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequestMapping("/api/raffle")
 @RequiredArgsConstructor
-@Tag(name = "Raffle-API", description = "응모권 API")
+@Tag(name = "응모권 관련 API", description = "상품 조회, 신청자 등록")
 public class RaffleController {
 
 	private final RaffleService raffleService;

--- a/backend/src/main/java/com/passtival/backend/global/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/passtival/backend/global/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.passtival.backend.global.auth.service.AuthService;
 import com.passtival.backend.global.common.BaseResponse;
 import com.passtival.backend.global.exception.BaseException;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증/인가 관련 API", description = "토큰 갱신")
 public class AuthController {
 
 	private final AuthService authService;


### PR DESCRIPTION
## 개요

관리자 로그인 기능이 도입되면서 분실물 등록 시, 인증키 입력 방식이 아닌, 관리자 토큰으로 인가 처리를 하도록 수정했습니다.
Swagger Tag를 모두 한글과 관련된 API 설명으로 수정해서 가독성을 높였고, 관련있는 API는 태그를 동일하게 하여 묶었습니다.
이후, 번호팅-카카오 로그인 리디렉션 API는 로그인 관련 API로 통일 시키면 좋을 것 같습니다.

<!---- Resolves: #(Isuue Number) -->
- close #76 
- close #75 

## PR 유형

### 📌 수정 및 변경(코드)
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링

## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
