### PR TITLE
fix: 메뉴 데이터 삽입 시 메뉴소개, 메뉴이미지 누락됨 -> 추가

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothSeedController.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/booth/controller/BoothSeedController.java
@@ -73,6 +73,8 @@ public class BoothSeedController {
 					booth.addMenu(Menu.builder()
 						.type(menuReq.getType())
 						.name(menuReq.getName())
+						.introduction(menuReq.getIntroduction())
+						.imagePath(menuReq.getImagePath())
 						.price(menuReq.getPrice())
 						.build());
 				}

--- a/backend/src/main/java/com/passtival/backend/domain/festival/booth/model/request/BoothRequest.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/booth/model/request/BoothRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class BoothRequest {
 
 	@Column(unique = true)
 	@NotBlank(message = "부스 이름은 필수 입력값입니다.")
+	@Size(max = 15, message = "부스 이름은 최대 15자 이내여야 합니다.")
 	private final String name;
 
 	@NotBlank(message = "부스 유형은 필수 입력값입니다.")
@@ -35,6 +37,7 @@ public class BoothRequest {
 	@NotBlank(message = "부스 위치는 필수 입력값입니다.")
 	private final String location;
 
+	@Size(max = 200, message = "부스 소개는 최대 200자 이내여야 합니다.")
 	private final String info;
 
 	private final String imagePath;
@@ -50,6 +53,8 @@ public class BoothRequest {
 	public static class MenuRequest {
 		private final String type;
 		private final String name;
-		private final int price;
+		private final String introduction;
+		private final String imagePath;
+		private final Integer price;
 	}
 }

--- a/backend/src/main/java/com/passtival/backend/domain/festival/booth/model/response/BoothResponse.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/booth/model/response/BoothResponse.java
@@ -24,7 +24,6 @@ public class BoothResponse {
 
 	/**
 	 * Booth 엔티티를 BoothResponseDTO로 변환하는 정적 팩토리 메서드
-	 *
 	 * @param booth Booth 엔티티
 	 * @return BoothResponseDTO 객체
 	 * @throws IllegalArgumentException booth가 null인 경우


### PR DESCRIPTION
## 메뉴 데이터 삽입 API
삽입할 데이터에 introduction, imagePath가 누락되어 추가하였습니다.
데이터 삽입시에 메뉴 소개와, 메뉴 이미지를 넣을 수 있습니다.

- close #35

### 📌 수정 및 변경(코드)
- [x] 코드 리팩토링

## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
