### PR TITLE
refactor: 기존의 관리자가 존재할 때 비밀번호 설정 방법 변경 #139

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/admin/initializer/AdminInitializer.java
+++ b/backend/src/main/java/com/passtival/backend/domain/admin/initializer/AdminInitializer.java
@@ -33,17 +33,18 @@ public class AdminInitializer implements ApplicationRunner {
 	}
 
 	private void initializeDefaultAdmin() {
-		//
-		Admin existingAdmin = adminRepository.findByLoginId(username)
-			.orElse(null);
-		if (existingAdmin != null) {
-			// 비밀번호 업데이트
-			existingAdmin.updateAuthKey(password);
-			adminRepository.save(existingAdmin);
+
+		// 이미 존재하는지 확인
+		Admin admin = adminRepository.findByLoginId(username).orElse(null);
+
+		// 존재하면 비밀번호 업데이트 후 종료
+		if (admin != null) {
+			admin.updatePassword(password);
+			adminRepository.save(admin);
 			return;
 		}
-
-		Admin admin = Admin.createAdmin(username, password);
+		// 존재하지 않으면 새로 생성
+		admin = Admin.createAdmin(username, password);
 		adminRepository.save(admin);
 
 	}

--- a/backend/src/main/java/com/passtival/backend/domain/admin/model/entity/Admin.java
+++ b/backend/src/main/java/com/passtival/backend/domain/admin/model/entity/Admin.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "admins")
+@Table(name = "admin")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -31,24 +31,23 @@ public class Admin {
 	@Column(name = "login_id", unique = true, nullable = false, length = 50)
 	private String loginId;
 
-	// BCrypt로 해싱된 값
-	@Column(name = "auth_key", nullable = false, length = 255)
-	private String authKey;
+	@Column(name = "password", nullable = false, length = 255)
+	private String password;
 
 	// 항상 ADMIN
 	@Column(nullable = false, length = 10)
 	@Enumerated(EnumType.STRING)
 	private Role role;
 
-	public static Admin createAdmin(String loginId, String hashedAuthKey) {
+	public static Admin createAdmin(String loginId, String password) {
 		return Admin.builder()
 			.loginId(loginId)
-			.authKey(hashedAuthKey)
+			.password(password)
 			.role(Role.ADMIN)
 			.build();
 	}
 
-	public void updateAuthKey(String newHashedAuthKey) {
-		this.authKey = newHashedAuthKey;
+	public void updatePassword(String newPassword) {
+		this.password = newPassword;
 	}
 }

--- a/backend/src/main/java/com/passtival/backend/domain/admin/service/AdminAuthService.java
+++ b/backend/src/main/java/com/passtival/backend/domain/admin/service/AdminAuthService.java
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Service;
 import com.passtival.backend.domain.admin.model.entity.Admin;
 import com.passtival.backend.domain.admin.model.request.AdminLoginRequest;
 import com.passtival.backend.domain.admin.repository.AdminRepository;
-import com.passtival.backend.global.security.model.token.TokenResponse;
-import com.passtival.backend.global.security.util.JwtUtil;
 import com.passtival.backend.global.common.BaseResponseStatus;
 import com.passtival.backend.global.exception.BaseException;
+import com.passtival.backend.global.security.model.token.TokenResponse;
+import com.passtival.backend.global.security.util.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +25,7 @@ public class AdminAuthService {
 			.orElseThrow(() -> new BaseException(BaseResponseStatus.ADMIN_LOGIN_FAILED));
 
 		// 인증키(다른 로그인 기준 password) 검증
-		if (!requestDto.getAuthKey().equals(admin.getAuthKey())) {
+		if (!requestDto.getAuthKey().equals(admin.getPassword())) {
 			throw new BaseException(BaseResponseStatus.ADMIN_LOGIN_FAILED);
 		}
 


### PR DESCRIPTION
## 개요
AdminInitializer와 Admin를 수정
AdminInitializer은 관리자가 존재할때 실행을 안 하는 방식에서 비밀번호(인증키)를 .env의 값으로 변경하는 형식으로 수정

Admin은 updateAuthKey를 만들어서 관리자가 존재할 때 인증키를 변경하는 메서드 생성

- close #139 

## PR 유형

### 📌 수정 및 변경(코드)
- [x] 코드 리팩토링

## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
