### PR TITLE
Refactor: 공연조회 id값 추가

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/festival/performance/model/response/PerformanceResponse.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/performance/model/response/PerformanceResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Builder
 public class PerformanceResponse {
 
+	private final Long id;
 	private final String title;
 	private final String artist;
 	private final LocalDateTime startTime;
@@ -22,6 +23,7 @@ public class PerformanceResponse {
 	public static PerformanceResponse of(Performance performance) {
 
 		return PerformanceResponse.builder()
+			.id(performance.getId())
 			.title(performance.getTitle())
 			.artist(performance.getArtist())
 			.startTime(performance.getStartTime())


### PR DESCRIPTION
## 개요
<img width="814" height="494" alt="image" src="https://github.com/user-attachments/assets/a289e1d6-8693-4765-a724-b8eab4163774" />
id값이 반환된 것이 없어 공연 id값을 몰라 단일 조회api를 호출 할 수 없습니다.
따라서 공연 api에 id값 반환 추가하여 id값도 같이 반환하도록 코드를 수정하였습니다.

- close #148

### 📌 수정 및 변경(코드)
- [x] 코드 리팩토링

## 🔥 PR Checklist
**리뷰어**를 위해, PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 리뷰어 설정을 했나요?
- [x] 커밋 메시지, 코드 컨벤션에 맞게 작성했나요?
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 🔥 병합 위치가 올바른 브랜치인지 확인하셨나요?
- [x] 진짜 했나요?
