### PR TITLE
Feat/170

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -64,7 +64,8 @@ dependencies {
 
     //Health Check
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
+    // Prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,6 +62,10 @@ dependencies {
     // Excel
     implementation 'org.apache.poi:poi-ooxml:5.2.5'
 
+    //Health Check
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //    testImplementation 'org.springframework.security:spring-security-test'

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
     container_name: passtival-spring-app
     ports:
-      - "127.0.0.1:8080:8080"
+      - "8080:8080"
     depends_on:
       - db
     env_file:
@@ -28,7 +28,24 @@ services:
       - KAKAO_USER_NAME_ATTRIBUTE=${KAKAO_USER_NAME_ATTRIBUTE}
     networks:
       - backend
+  grafana:
+    image: "grafana/grafana:latest"
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${ADMIN_USERNAME}
+      - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD}
+    container_name: grafana
 
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.dev.yml:/etc/prometheus/prometheus.yml
+    container_name: prometheus
+    networks:
+      - backend
   db:
     image: 'mysql:8.0'
     container_name: passtival-db

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -41,5 +41,43 @@ services:
     volumes:
       - /home/ubuntu/deploy/backend:/app/deploy
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - /home/ubuntu/monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - /home/ubuntu/monitoring/prometheus/rules.yml:/etc/prometheus/rules.yml:ro
+      - prom_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    networks:
+      - backend
+    restart: unless-stopped
+    depends_on:
+      - backend
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${ADMIN_USERNAME}
+      - GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+
+    volumes:
+      - grafana_data:/var/lib/grafana
+    networks:
+      - backend
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+
+volumes:
+  prom_data:
+  grafana_data:
+
 networks:
   backend:

--- a/backend/prometheus.dev.yml
+++ b/backend/prometheus.dev.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # Spring Boot 애플리케이션 메트릭
+  - job_name: 'passtival-backend'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 15s
+    static_configs:
+      - targets: [ 'backend:8080' ]
+    scrape_timeout: 15s
+
+  # Prometheus 자체 메트릭
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [ 'localhost:9090' ]

--- a/backend/src/main/java/com/passtival/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/passtival/backend/global/config/SecurityConfig.java
@@ -103,9 +103,9 @@ public class SecurityConfig {
 			.requestMatchers("/api/s3/**").permitAll()
 
 			//Health Check
-			.requestMatchers("/actuator/**").permitAll()
-			.requestMatchers("/readyz").permitAll()
-			.requestMatchers("/livez").permitAll()
+			.requestMatchers("/actuator/**").access(
+				new org.springframework.security.web.access.expression.WebExpressionAuthorizationManager(
+					"hasIpAddress('172.20.0.0/16') or hasIpAddress('172.18.0.4') or hasIpAddress('127.0.0.1')"))
 
 			// 모든 요청 로그인 후로 변경 잘못된 요청 전부 방어
 			.anyRequest().denyAll());

--- a/backend/src/main/java/com/passtival/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/passtival/backend/global/config/SecurityConfig.java
@@ -102,6 +102,11 @@ public class SecurityConfig {
 			// s3 업로드 (공개)
 			.requestMatchers("/api/s3/**").permitAll()
 
+			//Health Check
+			.requestMatchers("/actuator/**").permitAll()
+			.requestMatchers("/readyz").permitAll()
+			.requestMatchers("/livez").permitAll()
+
 			// 모든 요청 로그인 후로 변경 잘못된 요청 전부 방어
 			.anyRequest().denyAll());
 

--- a/backend/src/main/java/com/passtival/backend/global/health/CpuHealth.java
+++ b/backend/src/main/java/com/passtival/backend/global/health/CpuHealth.java
@@ -1,0 +1,36 @@
+package com.passtival.backend.global.health;
+
+import java.lang.management.ManagementFactory;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+
+import com.sun.management.OperatingSystemMXBean;
+
+@Component("cpuHealth")
+public class CpuHealth implements HealthIndicator {
+	// 90% 이상이면 경고 필요에 따라 .env 참고하게 설정 고민 중
+	private static final double MAX_LOAD = 0.90;
+
+	@Override
+	public Health health() {
+		OperatingSystemMXBean os =
+			(OperatingSystemMXBean)ManagementFactory.getOperatingSystemMXBean();
+
+		// 0.0~1.0, 지원 안 하면 -1
+		double load = os.getSystemCpuLoad();
+
+		if (load < 0) {
+			return Health.unknown().withDetail("reason", "unsupported").build();
+		}
+		// capacity 전용 'FATAL' 상태
+		if (load >= MAX_LOAD) {
+			return Health.status(new Status("FATAL"))
+				.withDetail("systemCpuLoad", load)
+				.build();
+		}
+		return Health.up().withDetail("systemCpuLoad", load).build();
+	}
+}

--- a/backend/src/main/java/com/passtival/backend/global/health/MemoryHealth.java
+++ b/backend/src/main/java/com/passtival/backend/global/health/MemoryHealth.java
@@ -1,0 +1,25 @@
+package com.passtival.backend.global.health;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+
+@Component("memoryHealth")
+public class MemoryHealth implements HealthIndicator {
+	// 예시: 사용 가능 메모리에 맞게 설정 필요 300MB 미만이면 FATAL
+	private static final long MIN_FREE_MB = 300;
+
+	@Override
+	public Health health() {
+		Runtime rt = Runtime.getRuntime();
+		long freeMb = (rt.maxMemory() - (rt.totalMemory() - rt.freeMemory())) / (1024 * 1024);
+
+		if (freeMb < MIN_FREE_MB) {
+			return Health.status(new Status("FATAL"))
+				.withDetail("freeMB", freeMb)
+				.build();
+		}
+		return Health.up().withDetail("freeMB", freeMb).build();
+	}
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -67,13 +67,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health"
+        include: health, info, metrics, prometheus
   endpoint:
     health:
-      show-details: "never"
+      show-details: "always"
       probes:
         enabled: true
-        add-additional-paths: true
       status:
         http-mapping:
           down: 503

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -63,3 +63,32 @@ frontend:
   login-url: ${FRONTEND_LOGIN_URL}
   login-fail-url: ${FRONTEND_LOGIN_FAIL_URL}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health"
+  endpoint:
+    health:
+      show-details: "never"
+      probes:
+        enabled: true
+        add-additional-paths: true
+      status:
+        http-mapping:
+          down: 503
+          out-of-service: 503
+      #해더 설정 후 변경 예정
+      validate-group-membership: true
+
+      group:
+        readiness:
+          include: "readinessState,db,diskSpace"
+        liveness:
+          include: "livenessState"
+        capacity:
+          include: "cpuHealth,memoryHealth"
+          status:
+            order: "fatal,down,out-of-service,up,unknown"
+            http-mapping:
+              fatal: 200

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -73,13 +73,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health"
+        include: health, info, metrics, prometheus
   endpoint:
     health:
       show-details: "never"
       probes:
         enabled: true
-        add-additional-paths: true
       status:
         http-mapping:
           down: 503

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -68,3 +68,32 @@ seed:
 frontend:
   login-url: ${FRONTEND_LOGIN_URL}
   login-fail-url: ${FRONTEND_LOGIN_FAIL_URL}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health"
+  endpoint:
+    health:
+      show-details: "never"
+      probes:
+        enabled: true
+        add-additional-paths: true
+      status:
+        http-mapping:
+          down: 503
+          out-of-service: 503
+      validate-group-membership: true
+
+      group:
+        readiness:
+          include: "readinessState,db,diskSpace"
+        liveness:
+          include: "livenessState"
+        capacity:
+          include: "cpuHealth,memoryHealth"
+          status:
+            order: "fatal,down,out-of-service,up,unknown"
+            http-mapping:
+              fatal: 200


### PR DESCRIPTION
## 개요

모니터링을 추가했습니다.
알람 설정은 추후 더 연결할 부분들이 남아있습니다.
EC2에 만든 rules.yml의 알람을 어디로 보낼지 설정하면 됩니다.

- close #170 

## 🛠️ 변경사항
ec2서버의 아래 2개의 파일 추가
```java
//~/monitoring/prometheus/prometheus.prod.yml 추가
global:
  scrape_interval: 15s
  evaluation_interval: 15s
rule_files:
  - /etc/prometheus/rules.yml
scrape_configs:
  - job_name: 'passtival-backend'
    metrics_path: /actuator/prometheus
    static_configs:
      - targets: ['backend:8080']
        labels:
          application: passtival
          env: prod
  - job_name: 'prometheus'
    static_configs:
      - targets: ['localhost:9090']
```
```java
//~/monitoring/prometheus/rules.yml추가

groups:
- name: capacity-rules
  rules:
  - alert: HighCPUUsage
    expr: process_cpu_usage{application="passtival"} > 0.90
    for: 5m
    labels: { severity: warning }
    annotations:
      summary: "CPU high on {{ $labels.instance }}"
  - alert: HighJVMHeapUsage
    expr: (sum(jvm_memory_used_bytes{area="heap",application="passtival"}) /
           sum(jvm_memory_max_bytes{area="heap",application="passtival"})) > 0.90
    for: 10m
    labels: { severity: warning }
    annotations:
      summary: "JVM heap high on {{ $labels.instance }}"
```
