### PR TITLE
fix: 배포 환경 모니터링의 도커 네트워크 대역을 잘 못 설정해서 값을 못 읽는 문제 해결

### DIFF
--- a/backend/src/main/java/com/passtival/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/passtival/backend/global/config/SecurityConfig.java
@@ -105,7 +105,7 @@ public class SecurityConfig {
 			//Health Check
 			.requestMatchers("/actuator/**").access(
 				new org.springframework.security.web.access.expression.WebExpressionAuthorizationManager(
-					"hasIpAddress('172.20.0.0/16') or hasIpAddress('172.18.0.4') or hasIpAddress('127.0.0.1')"))
+					"hasIpAddress('172.18.0.0/16') or hasIpAddress('127.0.0.1')"))
 
 			// 모든 요청 로그인 후로 변경 잘못된 요청 전부 방어
 			.anyRequest().denyAll());


### PR DESCRIPTION
## 개요
도커의 네트워크 설정을 잘못하여 값을 읽지 못하고 그로 인해 모니터링을 할 수 없는 문제가 발생했습니다.
- close #178 

## 🛠️ 변경사항
SecurityConfig의 헬스 체크 접근 가능한 네트워크를 수정했습니다.
```
.requestMatchers("/actuator/**").access(
				new org.springframework.security.web.access.expression.WebExpressionAuthorizationManager(
					"hasIpAddress('172.18.0.0/16') or hasIpAddress('127.0.0.1')"))
```
