### PR TITLE
[HotFix] 커서 API 쿼리문 버그로 수정합니다.

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/festival/booth/repository/BoothRepository.java
+++ b/backend/src/main/java/com/passtival/backend/domain/festival/booth/repository/BoothRepository.java
@@ -9,25 +9,23 @@ import org.springframework.data.repository.query.Param;
 
 import com.passtival.backend.domain.festival.booth.model.entity.Booth;
 
-
 public interface BoothRepository extends JpaRepository<Booth, Long> {
 
 	@Query("""
-	SELECT b FROM Booth b
-	WHERE (:cursorId IS NULL OR b.id < :cursorId)
-	ORDER BY
-  	CASE b.type
-  	  WHEN '학내부스' THEN 1
-  	  WHEN '체험'   THEN 2
- 	   WHEN '푸드존' THEN 3
-   	 WHEN '의료지원' THEN 4
-  	  ELSE 5
-  	END,
-  	b.name ASC,
-  	b.id DESC
-	""")
-	List<Booth> findPageByCursor(@Param("cursorId") Long cursorId,
-		Pageable pageable);
+		SELECT b FROM Booth b
+		WHERE (:cursorId IS NULL OR b.id < :cursorId)
+		ORDER BY
+		    CASE b.type
+		        WHEN '학내부스' THEN 1
+		        WHEN '체험' THEN 2
+		        WHEN '푸드존' THEN 3
+		        WHEN '의료지원' THEN 4
+		        ELSE 5
+		    END,
+		    b.name ASC,
+		    b.id DESC
+		""")
+	List<Booth> findPageByCursor(@Param("cursorId") Long cursorId, Pageable pageable);
 
 	boolean existsByName(String name);
 


### PR DESCRIPTION
## 개요
<!---- 목적 -->
<!---- Resolves: #(Isuue Number) -->
- close #180 

## 🛠️ 변경사항
<!---- 변경된 내용에 대해 설명해주세요. -->

들여쓰기 문제로 다시 수정합니다.

이전 코드

``` java
ublic interface BoothRepository extends JpaRepository<Booth, Long> {

	@Query("""
	SELECT b FROM Booth b
	WHERE (:cursorId IS NULL OR b.id < :cursorId)
	ORDER BY
  	CASE b.type
  	  WHEN '학내부스' THEN 1
  	  WHEN '체험'   THEN 2
 	   WHEN '푸드존' THEN 3
   	 WHEN '의료지원' THEN 4
  	  ELSE 5
  	END,
  	b.name ASC,
  	b.id DESC
	""")
	List<Booth> findPageByCursor(@Param("cursorId") Long cursorId,
		Pageable pageable);

	boolean existsByName(String name);

}
```

변경 후

``` java
public interface BoothRepository extends JpaRepository<Booth, Long> {

	@Query("""
		SELECT b FROM Booth b
		WHERE (:cursorId IS NULL OR b.id < :cursorId)
		ORDER BY
		    CASE b.type
		        WHEN '학내부스' THEN 1
		        WHEN '체험' THEN 2
		        WHEN '푸드존' THEN 3
		        WHEN '의료지원' THEN 4
		        ELSE 5
		    END,
		    b.name ASC,
		    b.id DESC
		""")
	List<Booth> findPageByCursor(@Param("cursorId") Long cursorId, Pageable pageable);

	boolean existsByName(String name);

}

```

## 🔍 참고사항
<!---- 참고할 사항이 있다면 작성해주세요. -->
