### PR TITLE
refactor: 번호팅 계정 조회 시 신청 유무를 함께 전달 하도록 수정

### DIFF
--- a/backend/src/main/java/com/passtival/backend/domain/matching/model/response/MatchingApplicantResponse.java
+++ b/backend/src/main/java/com/passtival/backend/domain/matching/model/response/MatchingApplicantResponse.java
@@ -17,4 +17,6 @@ public class MatchingApplicantResponse {
 	private String MemberPhoneNumber;
 
 	private String MemberInstagramId;
+
+	private boolean MemberApplied;
 }

--- a/backend/src/main/java/com/passtival/backend/domain/matching/service/MatchingApplicantService.java
+++ b/backend/src/main/java/com/passtival/backend/domain/matching/service/MatchingApplicantService.java
@@ -153,6 +153,7 @@ public class MatchingApplicantService {
 			.MemberGender(matchingApplicant.getGender())
 			.MemberPhoneNumber(matchingApplicant.getPhoneNumber())
 			.MemberInstagramId(matchingApplicant.getInstagramId())
+			.MemberApplied(matchingApplicant.isApplied())
 			.build();
 
 	}


### PR DESCRIPTION
## 개요

 번호팅 계정 조회 시 신청 유무를 함께 전달 하도록 수정

- close #181 

## 🛠️ 변경사항
MatchingApplicantResponse의 private boolean MemberApplied 추가
```
//서비스의 신청 유무 아래 같이 추가 
return MatchingApplicantResponse.builder()
			.MemberId(matchingApplicant.getMemberId())
			.MemberName(matchingApplicant.getName())
			.MemberGender(matchingApplicant.getGender())
			.MemberPhoneNumber(matchingApplicant.getPhoneNumber())
			.MemberInstagramId(matchingApplicant.getInstagramId())
			.MemberApplied(matchingApplicant.isApplied())
			.build();
```
