### PR TITLE
S3 Presigned URL 업로드 구조 개선 및 CloudFront CDN 적용

### DIFF
--- a/backend/src/main/java/com/passtival/backend/global/s3/controller/S3Controller.java
+++ b/backend/src/main/java/com/passtival/backend/global/s3/controller/S3Controller.java
@@ -1,5 +1,7 @@
 package com.passtival.backend.global.s3.controller;
 
+import com.passtival.backend.global.s3.dto.PresignedUrlResponse;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,32 +21,66 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/s3")
-@Tag(name = "S3 관련 API", description = "S3 이미지 업로드 URL(PreSignedURL) 조회")
+@Tag(name = "S3 API", description = "S3 이미지 업로드 및 URL 관리 API")
 public class S3Controller {
 
-	private final S3Service s3Service;
+    private final S3Service s3Service;
 
-	@Operation(
-		summary = "이미지 업로드 URL(PreSignedURL) 조회",
-		description = "클라이언트가 S3에 직접 이미지를 업로드하기 위한 Presigned URL을 생성합니다.",
-		parameters = {
-			@Parameter(
-				name = "fileName",
-				description = "업로드할 이미지 파일명 (확장자 포함)",
-				required = true,
-				in = ParameterIn.QUERY,
-				example = "lost-wallet.jpg"
-			)
-		}
-	)
-	@GetMapping("/upload-url")
-	public BaseResponse<String> getUploadUrl(
-		@RequestParam
-		@NotBlank(message = "파일명은 한글, 영문, 숫자, ., _, - 문자로 이루어져야 하며, 공백일 수 없으며, jpg, jpeg, png, gif, heic, webp 확장자를 포함해야 합니다.")
-		@Pattern(regexp = "^[\\w가-힣._-]+\\.(jpg|jpeg|png|gif|heic|webp)$",
-			message = "유효한 이미지 파일명이어야 합니다.")
-		String fileName) {
-		String uploadUrl = s3Service.getUploadUrl(fileName);
-		return BaseResponse.success(uploadUrl);
-	}
+    @Operation(
+            summary = "이미지 업로드용 Presigned URL 발급",
+            description = """
+                    클라이언트가 S3에 직접 이미지를 업로드할 수 있도록 Presigned URL을 생성합니다.
+
+                    [사용 흐름]
+                    1. 이 API 호출 → uploadUrl, objectKey, fileUrl 획득
+                    2. uploadUrl로 PUT 요청 → S3 업로드
+                    3. objectKey를 서버로 전달 → DB 저장
+                    4. fileUrl로 이미지 조회
+                    """
+    )
+    @GetMapping("/upload-url")
+    public BaseResponse<PresignedUrlResponse> getUploadUrl(
+
+            @Parameter(
+                    name = "directory",
+                    description = "저장 디렉토리 (booth, activity, menu 등)",
+                    example = "booth",
+                    required = true,
+                    in = ParameterIn.QUERY
+            )
+            @RequestParam
+            @NotBlank(message = "디렉토리는 필수입니다.")
+            String directory,
+
+            @Parameter(
+                    name = "id",
+                    description = "엔티티 ID (boothId 등)",
+                    example = "1",
+                    required = true,
+                    in = ParameterIn.QUERY
+            )
+            @RequestParam
+            @NotNull(message = "ID는 필수입니다.")
+            Long id,
+
+            @Parameter(
+                    name = "fileName",
+                    description = "업로드할 파일명 (확장자 포함)",
+                    example = "image.png",
+                    required = true,
+                    in = ParameterIn.QUERY
+            )
+            @RequestParam
+            @NotBlank(message = "파일명은 공백일 수 없습니다.")
+            @Pattern(
+                    regexp = "^[\\w가-힣._-]+\\.(jpg|jpeg|png|gif|heic|webp)$",
+                    message = "유효한 이미지 파일명이어야 합니다."
+            )
+            String fileName
+    ) {
+        PresignedUrlResponse response =
+                s3Service.generatePresignedUrl(directory, id, fileName);
+
+        return BaseResponse.success(response);
+    }
 }

--- a/backend/src/main/java/com/passtival/backend/global/s3/dto/PresignedUrlResponse.java
+++ b/backend/src/main/java/com/passtival/backend/global/s3/dto/PresignedUrlResponse.java
@@ -1,0 +1,13 @@
+package com.passtival.backend.global.s3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PresignedUrlResponse {
+
+    private String uploadUrl;   // S3 업로드용
+    private String objectKey;   // DB 저장용
+    private String fileUrl;     // CloudFront 조회용
+}

--- a/backend/src/main/java/com/passtival/backend/global/s3/service/S3Service.java
+++ b/backend/src/main/java/com/passtival/backend/global/s3/service/S3Service.java
@@ -3,6 +3,7 @@ package com.passtival.backend.global.s3.service;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Date;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import com.passtival.backend.global.s3.dto.PresignedUrlResponse;
@@ -13,32 +14,37 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
-@RequiredArgsConstructor
 public class S3Service {
 
-	private final AmazonS3 amazonS3;
+    private final AmazonS3 amazonS3;
+    private final String bucketName;
+    private final int expirationMinutes;
+    private final String cloudFrontDomain;
 
-	@Value("${cloud.aws.s3.bucket}")
-	private String bucketName;
+    public S3Service(
+            AmazonS3 amazonS3,
+            @Value("${cloud.aws.s3.bucket}") String bucketName,
+            @Value("${cloud.aws.s3.presigned-url.expiration-minutes:10}") int expirationMinutes,
+            @Value("${cloud.aws.cloudfront.domain}") String cloudFrontDomain
+    ) {
+        this.amazonS3 = amazonS3;
+        this.bucketName = bucketName;
+        this.expirationMinutes = expirationMinutes;
+        this.cloudFrontDomain = cloudFrontDomain;
+    }
 
-	@Value("${cloud.aws.s3.presigned-url.expiration-minutes:10}")
-	private int expirationMinutes;
-
-    // CloudFront 도메인
-    @Value("${cloud.aws.cloudfront.domain}")
-    private String cloudFrontDomain;
-
-    // Presigned URL 생성 (업로드용 - public)
     public PresignedUrlResponse generatePresignedUrl(String directory, Long id, String originalFileName) {
 
         // UUID 파일명
         String uniqueFileName = UUID.randomUUID() + "_" + originalFileName;
 
-        // objectKey
-        String objectKey = String.format("public/%s/%d/%s", directory, id, uniqueFileName);
+        // 🔥 현재 연도 추가
+        String year = String.valueOf(LocalDate.now().getYear());
+
+        // objectKey (year 포함)
+        String objectKey = String.format("public/%s/%s/%d/%s",
+                year, directory, id, uniqueFileName);
 
         // 만료 시간
         Date expiration = new Date(System.currentTimeMillis()
@@ -60,5 +66,4 @@ public class S3Service {
                 fileUrl
         );
     }
-
 }

--- a/backend/src/main/java/com/passtival/backend/global/s3/service/S3Service.java
+++ b/backend/src/main/java/com/passtival/backend/global/s3/service/S3Service.java
@@ -3,7 +3,9 @@ package com.passtival.backend.global.s3.service;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Date;
+import java.util.UUID;
 
+import com.passtival.backend.global.s3.dto.PresignedUrlResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -25,26 +27,38 @@ public class S3Service {
 	@Value("${cloud.aws.s3.presigned-url.expiration-minutes:10}")
 	private int expirationMinutes;
 
-	public String generatePresignedUrl(String fileName) {
-		// S3 객체 키 생성
-		String objectKey = "images/found/" + fileName;
+    // CloudFront 도메인
+    @Value("${cloud.aws.cloudfront.domain}")
+    private String cloudFrontDomain;
 
-		// Presigned Url 만료 시간 설정
-		Date expiration = new Date(System.currentTimeMillis() + Duration.ofMinutes(expirationMinutes).toMillis());
+    // Presigned URL 생성 (업로드용 - public)
+    public PresignedUrlResponse generatePresignedUrl(String directory, Long id, String originalFileName) {
 
-		// Presigned URL 요청 생성
-		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, objectKey)
-			.withMethod(HttpMethod.PUT)
-			.withExpiration(expiration);
+        // UUID 파일명
+        String uniqueFileName = UUID.randomUUID() + "_" + originalFileName;
 
-		// Presigned URL 생성
-		URL presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+        // objectKey
+        String objectKey = String.format("public/%s/%d/%s", directory, id, uniqueFileName);
 
-		return presignedUrl.toString();
-	}
+        // 만료 시간
+        Date expiration = new Date(System.currentTimeMillis()
+                + Duration.ofMinutes(expirationMinutes).toMillis());
 
-	public String getUploadUrl(String fileName) {
-		return generatePresignedUrl(fileName);
-	}
+        GeneratePresignedUrlRequest request =
+                new GeneratePresignedUrlRequest(bucketName, objectKey)
+                        .withMethod(HttpMethod.PUT)
+                        .withExpiration(expiration);
+
+        URL presignedUrl = amazonS3.generatePresignedUrl(request);
+
+        // CloudFront URL
+        String fileUrl = cloudFrontDomain + "/" + objectKey;
+
+        return new PresignedUrlResponse(
+                presignedUrl.toString(),
+                objectKey,
+                fileUrl
+        );
+    }
 
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,6 +41,9 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  docker:
+    compose:
+      enabled: false
 
 server:
   forward-headers-strategy: native
@@ -56,6 +59,8 @@ cloud:
       bucket: ${AWS_S3_BUCKET}
       presigned-url:
         expiration-minutes: 10 # presigned URL 만료 시간 (분 단위)
+    cloudfront:
+      domain: ${CLOUDFRONT_DOMAIN}
 
 discord:
   webhook:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,9 +41,6 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
-  docker:
-    compose:
-      enabled: false
 
 server:
   forward-headers-strategy: native


### PR DESCRIPTION
## 개요

- S3 + CloudFront 기반 정적 파일 업로드 및 조회 구조를 도입했습니다.
- 이미지 업로드는 기존 Presigned URL 방식으로 처리하고, 조회는 CDN(CloudFront)을 통해 제공하도록 개선했습니다.
- close #242

## 작업 내용

1. 응답 구조 확장

기존:
- Presigned URL만 반환

변경:
- uploadUrl (업로드용 URL)
- objectKey (DB 저장용)
- fileUrl (CloudFront 조회용)
-> 업로드, 저장, 조회 흐름을 일관되게 처리 가능
3. CloudFront 기반 조회 구조 적용
    - S3 직접 접근 제거
    - CDN을 통한 이미지 조회
    - 응답 속도 개선 및 캐싱 활용
4. 파일 저장 구조 표준화
`public/{directory}/{id}/{uuid}_{fileName}`
예:
`public/booth/1/uuid_image.png`
5. 환경변수 기반 설정 적용
    - S3 bucket (현재 passtival-dev-static, passtival-prod-static 존재)
    - CloudFront domain
        - application.yml + 환경변수로 관리

## 변경 사항

🔹 Controller
•	/api/s3/upload-url API 수정
•	PresignedUrlResponse 반환하도록 변경
•	directory, id, fileName 파라미터 추가

🔹 Service
•	Presigned URL 생성 로직 구현
•	UUID 기반 파일명 생성 (충돌 방지)
•	CloudFront URL 생성 로직 추가

🔹 DTO
•	PresignedUrlResponse 생성
•	uploadUrl
•	objectKey
•	fileUrl 포함

## 업로드 흐름

1. 클라이언트 → Presigned URL 요청
2. 서버 → uploadUrl + objectKey + fileUrl 반환
3. 클라이언트 → uploadUrl로 S3에 PUT 업로드
4. 클라이언트 → objectKey를 서버에 전달하여 DB 저장 (현재는 미사용, 추후 이미지 관리 기능에서 활용 예정)
6. 클라이언트 → fileUrl로 이미지 조회

## 🔍 참고사항

- .env파일에 cdn주소 추가해야합니다.
- .yml파일에 개발환경 버킷 (passtival-dev-static)과 배포환경 버킷 (passtival-prod-static)을 추가해야합니다.